### PR TITLE
Slim Docker images by using Alpine versions, update Python to 3.5

### DIFF
--- a/liveblog/Dockerfile
+++ b/liveblog/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.5-alpine
 ENV PYTHONUNBUFFERED 1
 ENV REDIS_HOST "redis"
 RUN mkdir /code

--- a/liveblog/docker-compose.yml
+++ b/liveblog/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   redis:
-    image: redis:latest
+    image: redis:alpine
   web:
     build: .
     command: python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
The differences are pretty dramatic:

```
redis                   alpine              8a8bdae38335        7 days ago          29.07 MB
redis                   latest               43c923d57784        7 days ago          193.9 MB

python                  3.5-alpine      a35dc90b7d05        6 days ago          71.46 MB
python                  latest             a00e9008965a        6 days ago          697.7 MB
python                  3.4                 2d5a4cc9135c        6 days ago          695.1 MB
```
