### PR TITLE
Set path at the route for the databinding example

### DIFF
--- a/databinding/databinding/routing.py
+++ b/databinding/databinding/routing.py
@@ -8,6 +8,6 @@ from values.models import IntegerValueBinding
 # all WebSocket connections to the class-based BindingConsumer (the consumer
 # class itself specifies what channels it wants to consume)
 channel_routing = [
-    route_class(Demultiplexer),
+    route_class(Demultiplexer, path='^/stream/?$'),
     route("binding.intval", IntegerValueBinding.consumer),
 ]

--- a/databinding/values/models.py
+++ b/databinding/values/models.py
@@ -15,7 +15,7 @@ class IntegerValueBinding(WebsocketBinding):
     fields = ["name", "value"]
 
     @classmethod
-    def group_names(cls, instance):
+    def group_names(cls, *args, **kwargs):
         return ["binding.values"]
 
     def has_permission(self, user, action, pk):

--- a/multichat/chat/utils.py
+++ b/multichat/chat/utils.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from .exceptions import ClientError
 from .models import Room
 
@@ -6,9 +8,10 @@ def catch_client_error(func):
     """
     Decorator to catch the ClientError exception and translate it into a reply.
     """
-    def inner(message):
+    @wraps(func)
+    def inner(message, *args, **kwargs):
         try:
-            return func(message)
+            return func(message, *args, **kwargs)
         except ClientError as e:
             # If we catch a client error, tell it to send an error string
             # back to the client on their reply channel


### PR DESCRIPTION
Using args/kwargs at the group_names for the  IntegerValueBinding
Wrap  decorated consumer at the catch_client_error decorator
