### PR TITLE
Fix liveblog dockerfile

### DIFF
--- a/liveblog/Dockerfile
+++ b/liveblog/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:3.5
 ENV PYTHONUNBUFFERED 1
 ENV REDIS_HOST "redis"
 RUN mkdir /code


### PR DESCRIPTION
Alpine-based Python3.5 image has no gcc on a board and twisted install fails with following error:

```
    running build_ext
    building 'twisted.test.raiser' extension
    creating build/temp.linux-x86_64-3.5
    creating build/temp.linux-x86_64-3.5/src
    creating build/temp.linux-x86_64-3.5/src/twisted
    creating build/temp.linux-x86_64-3.5/src/twisted/test
    gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/usr/local/include/python3.5m -c src/twisted/test/raiser.c -o build/temp.linux-x86_64-3.5/src/twisted/test/raiser.o
    unable to execute 'gcc': No such file or directory
    error: command 'gcc' failed with exit status 1

    ----------------------------------------
Command "/usr/local/bin/python3.5 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-yj_qtaqh/twisted/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-plprvkdm-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-yj_qtaqh/twisted/
ERROR: Service 'web' failed to build: The command '/bin/sh -c pip install -r requirements.txt' returned a non-zero code: 1
```

Since it is a demo and size does not actually matters, this commit reverts Alpine image to default one.