### PR TITLE
databinding: Change jquery binding for changing sliders so new values work too.

### DIFF
--- a/databinding/templates/index.html
+++ b/databinding/templates/index.html
@@ -58,7 +58,7 @@
             };
 
             // Bind changing the slider value
-            $("input").on("change", function () {
+            $("#values").on("change", "input", function () {
                 $(this).parent().find("output").val($(this).val());
                 socket.send(JSON.stringify({
                     "stream": "intval",


### PR DESCRIPTION
The jquery binding for slider changes is applied to only the `input` tags that already exist.  So new values, while appearing and receiving updates from other sources, do not send updates until the page is reloaded.

This change instead binds the function to `#values`, filtered by `input` tag and type `change`.  That way new values also work.

BTW, thanks for providing these examples--they show exactly what I wanted to know about getting start with channels.