### PR TITLE
Issue/django 2 compatibility

### DIFF
--- a/databinding/databinding/settings.py
+++ b/databinding/databinding/settings.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     'values',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/liveblog/liveblog/settings/base.py
+++ b/liveblog/liveblog/settings/base.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     'posts',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/multichat/chat/utils.py
+++ b/multichat/chat/utils.py
@@ -24,7 +24,7 @@ def get_room_or_error(room_id, user):
     Tries to fetch a room for the user, checking permissions along the way.
     """
     # Check if the user is logged in
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         raise ClientError("USER_HAS_TO_LOGIN")
     # Find the room they requested (by ID)
     try:

--- a/multichat/multichat/settings.py
+++ b/multichat/multichat/settings.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     'chat',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Reproducing the issues:
- **First commit** c6cbb86
Applies for all examples. Trying to sign in the admin area, throws the error message below:
`
contrib/admin/sites.py", line 186, in has_permission
    return request.user.is_active and request.user.is_staff
AttributeError: 'AsgiRequest' object has no attribute 'user'
`

- **Second commit** d2ea5ec 
Using multichat example, while trying to get in a `staff only` room with a non stuff user, throws the error message below:
`
channels-examples/multichat/chat/utils.py", line 27, in get_room_or_error
    if not user.is_authenticated():
TypeError: 'bool' object is not callable
`