### PR TITLE
Made multichat example working again

### DIFF
--- a/multichat/chat/utils.py
+++ b/multichat/chat/utils.py
@@ -24,7 +24,7 @@ def get_room_or_error(room_id, user):
     Tries to fetch a room for the user, checking permissions along the way.
     """
     # Check if the user is logged in
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         raise ClientError("USER_HAS_TO_LOGIN")
     # Find the room they requested (by ID)
     try:

--- a/multichat/multichat/settings.py
+++ b/multichat/multichat/settings.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     'chat',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/multichat/requirements.txt
+++ b/multichat/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.9
-channels>=1.1.2
-asgi_redis>=0.9
+Django==2.0.1
+channels==1.1.8
+asgi_redis==1.4.3


### PR DESCRIPTION
I wanted to try `channels` using these examples and ended up somewhat frustrated because it would only get `'AsgiRequest' object has no attribute 'user'` errors.

Apparently the reason was, the `requirements.txt` would only specify `>=` versions of Django and channels. Hence, it installed `2.0.1` and `1.1.8`. I think in Django 1.10 `MIDDLEWARE_CLASSES` was renamed to `MIDDLEWARE` and since Django 2.0 `user.is_authenticated` is simply a boolean. 

So I decided to contribute these minor changes in order for other new users not to run into these pitfalls (and maybe turning away from the project)