### PR TITLE
Switch from docker image python:3.6 to python:3.6-stretch

### DIFF
--- a/multichat/Dockerfile
+++ b/multichat/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-stretch
 ENV PYTHONUNBUFFERED 1
 ENV REDIS_HOST "redis"
 RUN mkdir /code


### PR DESCRIPTION
python:3.6 is based on jessie (oldstable)