### PR TITLE
 Header name 'Content-Type' expected to be `bytes`, but got `<class '…

### DIFF
--- a/news_collector/collector/consumers.py
+++ b/news_collector/collector/consumers.py
@@ -47,6 +47,6 @@ class NewsCollectorAsyncConsumer(AsyncHttpConsumer):
         await self.send_response(200,
             text.encode(),
             headers=[
-                ("Content-Type", "application/json"),
+                (b"Content-Type", b"application/json"),
             ]
         )


### PR DESCRIPTION
…str'>`

Whenever sending the async response page freeze cause is expecting bytes and it is receiving `<class 'str'>`.
As a simple solution let us just do that:

headers=[
                (b"Content-Type", b "application/json"),
            ]